### PR TITLE
change css selectors which find Okta page elements for new Okta account

### DIFF
--- a/test/testlib/browsertest/browsertest.go
+++ b/test/testlib/browsertest/browsertest.go
@@ -359,9 +359,9 @@ func LoginToUpstreamOIDC(t *testing.T, b *Browser, upstream testlib.TestOIDCUpst
 			Name:                "Okta",
 			IssuerPattern:       regexp.MustCompile(`\Ahttps://.+\.okta\.com/.+\z`),
 			LoginPagePattern:    regexp.MustCompile(`\Ahttps://.+\.okta\.com/.*\z`),
-			UsernameSelector:    "input#okta-signin-username",
-			PasswordSelector:    "input#okta-signin-password",
-			LoginButtonSelector: "input#okta-signin-submit",
+			UsernameSelector:    "input[type=text]",
+			PasswordSelector:    "input[type=password]",
+			LoginButtonSelector: "input[type=submit]",
 		},
 		{
 			Name:                "Dex",


### PR DESCRIPTION
Unfortunately, Okta discontinued the free developer preview accounts. Fortunately, they offer a new free integrator account which is basically the same thing. I signed up for a new integrator account and configured the account for our integration tests that run in CI. However, the new Okta login page needs new CSS selectors to find the username and password inputs and the submit button. This PR updates our integration tests to use new CSS selectors for that.

**Release note**:

```release-note
NONE
```
