### PR TITLE
adjust test code to allow for using Okta LDAP in integration tests

### DIFF
--- a/hack/prepare-for-integration-tests.sh
+++ b/hack/prepare-for-integration-tests.sh
@@ -517,6 +517,7 @@ export PINNIPED_TEST_LDAP_BIND_ACCOUNT_USERNAME="cn=admin,dc=pinniped,dc=dev"
 export PINNIPED_TEST_LDAP_BIND_ACCOUNT_PASSWORD=password
 export PINNIPED_TEST_LDAP_USERS_SEARCH_BASE="ou=users,dc=pinniped,dc=dev"
 export PINNIPED_TEST_LDAP_GROUPS_SEARCH_BASE="ou=groups,dc=pinniped,dc=dev"
+export PINNIPED_TEST_LDAP_GROUPS_SEARCH_FILTER=""
 export PINNIPED_TEST_LDAP_USER_DN="cn=pinny,ou=users,dc=pinniped,dc=dev"
 export PINNIPED_TEST_LDAP_USER_CN="pinny"
 export PINNIPED_TEST_LDAP_USER_PASSWORD=${ldap_test_password}

--- a/hack/prepare-supervisor-on-kind.sh
+++ b/hack/prepare-supervisor-on-kind.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2021-2024 the Pinniped contributors. All Rights Reserved.
+# Copyright 2021-2025 the Pinniped contributors. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 #
@@ -246,6 +246,7 @@ spec:
     secretName: my-ldap-service-account
   groupSearch:
     base: "$PINNIPED_TEST_LDAP_GROUPS_SEARCH_BASE"
+    filter: "$PINNIPED_TEST_LDAP_GROUPS_SEARCH_FILTER"
     attributes:
       groupName: "cn"
   userSearch:

--- a/test/integration/audit_test.go
+++ b/test/integration/audit_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -172,7 +173,7 @@ func TestAuditLogsDuringLogin_Disruptive(t *testing.T) {
 			"message": "Session Started",
 			"personalInfo": map[string]any{
 				"username":         "redacted",
-				"groups":           []any{"redacted 2 values"},
+				"groups":           []any{fmt.Sprintf("redacted %d values", len(expectedGroups))},
 				"subject":          "redacted",
 				"additionalClaims": map[string]any{"redacted": "redacted 0 keys"},
 			},
@@ -208,7 +209,7 @@ func TestAuditLogsDuringLogin_Disruptive(t *testing.T) {
 			},
 			"personalInfo": map[string]any{
 				"username": "redacted",
-				"groups":   []any{"redacted 2 values"},
+				"groups":   []any{fmt.Sprintf("redacted %d values", len(expectedGroups))},
 				"extras":   map[string]any{"redacted": "redacted 1 keys"},
 			},
 		},

--- a/test/integration/e2e_test.go
+++ b/test/integration/e2e_test.go
@@ -2010,7 +2010,7 @@ func setupClusterForEndToEndLDAPTest(t *testing.T, username string, env *testlib
 		},
 		GroupSearch: idpv1alpha1.LDAPIdentityProviderGroupSearch{
 			Base:   env.SupervisorUpstreamLDAP.GroupSearchBase,
-			Filter: "", // use the default value of "member={}"
+			Filter: env.SupervisorUpstreamLDAP.GroupSearchFilter, // if empty, uses the default value of "member={}"
 			Attributes: idpv1alpha1.LDAPIdentityProviderGroupSearchAttributes{
 				GroupName: "", // use the default value of "dn"
 			},

--- a/test/integration/supervisor_discovery_test.go
+++ b/test/integration/supervisor_discovery_test.go
@@ -952,7 +952,7 @@ func requireIDPsListedByIDPDiscoveryEndpoint(
 		},
 		GroupSearch: idpv1alpha1.LDAPIdentityProviderGroupSearch{
 			Base:   env.SupervisorUpstreamLDAP.GroupSearchBase,
-			Filter: "", // use the default value of "member={}"
+			Filter: env.SupervisorUpstreamLDAP.GroupSearchFilter, // if empty, uses the default value of "member={}"
 			Attributes: idpv1alpha1.LDAPIdentityProviderGroupSearchAttributes{
 				GroupName: "", // use the default value of "dn"
 			},

--- a/test/integration/supervisor_ldap_idp_test.go
+++ b/test/integration/supervisor_ldap_idp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2024 the Pinniped contributors. All Rights Reserved.
+// Copyright 2024-2025 the Pinniped contributors. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package integration
@@ -63,7 +63,7 @@ func TestLDAPIDPPhaseAndConditions_Parallel(t *testing.T) {
 		},
 		GroupSearch: idpv1alpha1.LDAPIdentityProviderGroupSearch{
 			Base:   env.SupervisorUpstreamLDAP.GroupSearchBase,
-			Filter: "", // use the default value of "member={}"
+			Filter: env.SupervisorUpstreamLDAP.GroupSearchFilter, // if empty, uses the default value of "member={}"
 			Attributes: idpv1alpha1.LDAPIdentityProviderGroupSearchAttributes{
 				GroupName: "", // use the default value of "dn"
 			},

--- a/test/integration/supervisor_login_test.go
+++ b/test/integration/supervisor_login_test.go
@@ -277,7 +277,7 @@ func TestSupervisorLogin_Browser(t *testing.T) {
 			},
 			GroupSearch: idpv1alpha1.LDAPIdentityProviderGroupSearch{
 				Base:                   env.SupervisorUpstreamLDAP.GroupSearchBase,
-				Filter:                 "",
+				Filter:                 env.SupervisorUpstreamLDAP.GroupSearchFilter, // if empty, uses the default value of "member={}"
 				UserAttributeForFilter: "",
 				Attributes: idpv1alpha1.LDAPIdentityProviderGroupSearchAttributes{
 					GroupName: "dn",

--- a/test/testlib/env.go
+++ b/test/testlib/env.go
@@ -112,6 +112,7 @@ type TestLDAPUpstream struct {
 	UserSearchBase                                  string   `json:"userSearchBase"`
 	DefaultNamingContextSearchBase                  string   `json:"defaultNamingContextSearchBase"`
 	GroupSearchBase                                 string   `json:"groupSearchBase"`
+	GroupSearchFilter                               string   `json:"groupSearchFilter"`
 	TestUserDN                                      string   `json:"testUserDN"`
 	TestUserCN                                      string   `json:"testUserCN"`
 	TestUserPassword                                string   `json:"testUserPassword"`
@@ -337,6 +338,7 @@ func loadEnvVars(t *testing.T, result *TestEnv) {
 		BindPassword:                   needEnv(t, "PINNIPED_TEST_LDAP_BIND_ACCOUNT_PASSWORD"),
 		UserSearchBase:                 needEnv(t, "PINNIPED_TEST_LDAP_USERS_SEARCH_BASE"),
 		GroupSearchBase:                needEnv(t, "PINNIPED_TEST_LDAP_GROUPS_SEARCH_BASE"),
+		GroupSearchFilter:              wantEnv("PINNIPED_TEST_LDAP_GROUPS_SEARCH_FILTER", ""),
 		TestUserDN:                     needEnv(t, "PINNIPED_TEST_LDAP_USER_DN"),
 		TestUserCN:                     needEnv(t, "PINNIPED_TEST_LDAP_USER_CN"),
 		TestUserUniqueIDAttributeName:  needEnv(t, "PINNIPED_TEST_LDAP_USER_UNIQUE_ID_ATTRIBUTE_NAME"),
@@ -344,7 +346,7 @@ func loadEnvVars(t *testing.T, result *TestEnv) {
 		TestUserMailAttributeName:      needEnv(t, "PINNIPED_TEST_LDAP_USER_EMAIL_ATTRIBUTE_NAME"),
 		TestUserMailAttributeValue:     needEnv(t, "PINNIPED_TEST_LDAP_USER_EMAIL_ATTRIBUTE_VALUE"),
 		TestUserDirectGroupsCNs:        filterEmpty(strings.Split(needEnv(t, "PINNIPED_TEST_LDAP_EXPECTED_DIRECT_GROUPS_CN"), ";")),
-		TestUserDirectPosixGroupsCNs:   filterEmpty(strings.Split(needEnv(t, "PINNIPED_TEST_LDAP_EXPECTED_DIRECT_POSIX_GROUPS_CN"), ";")),
+		TestUserDirectPosixGroupsCNs:   filterEmpty(strings.Split(wantEnv("PINNIPED_TEST_LDAP_EXPECTED_DIRECT_POSIX_GROUPS_CN", ""), ";")),
 		TestUserDirectGroupsDNs:        filterEmpty(strings.Split(needEnv(t, "PINNIPED_TEST_LDAP_EXPECTED_DIRECT_GROUPS_DN"), ";")),
 		TestUserPassword:               needEnv(t, "PINNIPED_TEST_LDAP_USER_PASSWORD"),
 	}


### PR DESCRIPTION
Okta LDAP requires using a different groups search filter, so make that configurable. It also does not support posix groups, so make that expected value optional.

**Release note**:

```release-note
NONE
```
