### PR TITLE
feat: Support OAuth 2.0 Device Authorization Grant (RFC 8628) in Pinniped CLI

### DIFF
--- a/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go.tmpl
+++ b/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go.tmpl
@@ -19,6 +19,7 @@ const (
 
 	IDPFlowCLIPassword     IDPFlow = "cli_password"
 	IDPFlowBrowserAuthcode IDPFlow = "browser_authcode"
+	IDPFlowDeviceCode      IDPFlow = "device_code"
 )
 
 // Equals is a convenience function for comparing an IDPType to a string.

--- a/generated/1.31/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
+++ b/generated/1.31/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
@@ -19,6 +19,7 @@ const (
 
 	IDPFlowCLIPassword     IDPFlow = "cli_password"
 	IDPFlowBrowserAuthcode IDPFlow = "browser_authcode"
+	IDPFlowDeviceCode      IDPFlow = "device_code"
 )
 
 // Equals is a convenience function for comparing an IDPType to a string.

--- a/generated/1.32/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
+++ b/generated/1.32/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
@@ -19,6 +19,7 @@ const (
 
 	IDPFlowCLIPassword     IDPFlow = "cli_password"
 	IDPFlowBrowserAuthcode IDPFlow = "browser_authcode"
+	IDPFlowDeviceCode      IDPFlow = "device_code"
 )
 
 // Equals is a convenience function for comparing an IDPType to a string.

--- a/generated/1.33/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
+++ b/generated/1.33/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
@@ -19,6 +19,7 @@ const (
 
 	IDPFlowCLIPassword     IDPFlow = "cli_password"
 	IDPFlowBrowserAuthcode IDPFlow = "browser_authcode"
+	IDPFlowDeviceCode      IDPFlow = "device_code"
 )
 
 // Equals is a convenience function for comparing an IDPType to a string.

--- a/generated/1.34/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
+++ b/generated/1.34/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
@@ -19,6 +19,7 @@ const (
 
 	IDPFlowCLIPassword     IDPFlow = "cli_password"
 	IDPFlowBrowserAuthcode IDPFlow = "browser_authcode"
+	IDPFlowDeviceCode      IDPFlow = "device_code"
 )
 
 // Equals is a convenience function for comparing an IDPType to a string.

--- a/generated/1.35/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
+++ b/generated/1.35/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
@@ -19,6 +19,7 @@ const (
 
 	IDPFlowCLIPassword     IDPFlow = "cli_password"
 	IDPFlowBrowserAuthcode IDPFlow = "browser_authcode"
+	IDPFlowDeviceCode      IDPFlow = "device_code"
 )
 
 // Equals is a convenience function for comparing an IDPType to a string.

--- a/generated/1.36/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
+++ b/generated/1.36/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
@@ -19,6 +19,7 @@ const (
 
 	IDPFlowCLIPassword     IDPFlow = "cli_password"
 	IDPFlowBrowserAuthcode IDPFlow = "browser_authcode"
+	IDPFlowDeviceCode      IDPFlow = "device_code"
 )
 
 // Equals is a convenience function for comparing an IDPType to a string.

--- a/generated/latest/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
+++ b/generated/latest/apis/supervisor/idpdiscovery/v1alpha1/types_supervisor_idp_discovery.go
@@ -19,6 +19,7 @@ const (
 
 	IDPFlowCLIPassword     IDPFlow = "cli_password"
 	IDPFlowBrowserAuthcode IDPFlow = "browser_authcode"
+	IDPFlowDeviceCode      IDPFlow = "device_code"
 )
 
 // Equals is a convenience function for comparing an IDPType to a string.

--- a/pkg/oidcclient/devicecode.go
+++ b/pkg/oidcclient/devicecode.go
@@ -1,0 +1,197 @@
+package oidcclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"go.pinniped.dev/pkg/oidcclient/oidctypes"
+)
+
+// RFC 8628 Device Authorization Response
+type deviceAuthorizationResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete,omitempty"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval,omitempty"`
+}
+
+// OAuth2 Error Response
+type oauth2ErrorResponse struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
+}
+
+// deviceCodeBasedAuth performs the RFC 8628 Device Authorization Grant flow.
+func (h *handlerState) deviceCodeBasedAuth(_ *[]oauth2.AuthCodeOption) (*oidctypes.Token, error) {
+	// Get the device authorization endpoint from the provider's discovery document.
+	var claims struct {
+		DeviceAuthorizationEndpoint string `json:"device_authorization_endpoint"`
+	}
+	if err := h.provider.Claims(&claims); err != nil || claims.DeviceAuthorizationEndpoint == "" {
+		return nil, fmt.Errorf("issuer does not support device authorization grant (missing device_authorization_endpoint in discovery)")
+	}
+
+	// Send a request to the device authorization endpoint to get a device code and user code.
+	reqBody := url.Values{}
+	reqBody.Set("client_id", h.clientID)
+	reqBody.Set("scope", strings.Join(h.scopes, " "))
+
+	reqCtx, reqCancel := context.WithTimeout(h.ctx, httpRequestTimeout)
+	defer reqCancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, claims.DeviceAuthorizationEndpoint, strings.NewReader(reqBody.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("could not build device authorization request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := h.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("device authorization request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("device authorization endpoint returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	var deviceResp deviceAuthorizationResponse
+	if err := json.NewDecoder(resp.Body).Decode(&deviceResp); err != nil {
+		return nil, fmt.Errorf("failed to decode device authorization response: %w", err)
+	}
+
+	interval := time.Duration(deviceResp.Interval) * time.Second
+	if interval <= 0 {
+		interval = 5 * time.Second
+	}
+
+	// Display the verification URL and user code to the user.
+	displayURL := deviceResp.VerificationURI
+	if deviceResp.VerificationURIComplete != "" {
+		displayURL = deviceResp.VerificationURIComplete
+	}
+
+	fmt.Fprintf(h.out, "\nPlease visit the following URL to authenticate:\n")
+	fmt.Fprintf(h.out, "  URL:  %s\n", displayURL)
+	if deviceResp.VerificationURIComplete == "" {
+		fmt.Fprintf(h.out, "  Code: %s\n", deviceResp.UserCode)
+	}
+	fmt.Fprintf(h.out, "\nWaiting for authentication...\n")
+
+	// Poll the token endpoint for the access token and ID token.
+	tokenEndpoint := h.oauth2Config.Endpoint.TokenURL
+	pollTicker := time.NewTicker(interval)
+	defer pollTicker.Stop()
+
+	for {
+		select {
+		case <-h.ctx.Done():
+			return nil, fmt.Errorf("timed out waiting for device authorization: %w", h.ctx.Err())
+
+		case <-pollTicker.C:
+			tokenReqBody := url.Values{}
+			tokenReqBody.Set("grant_type", "urn:ietf:params:oauth:grant-type:device_code")
+			tokenReqBody.Set("device_code", deviceResp.DeviceCode)
+			tokenReqBody.Set("client_id", h.clientID)
+
+			tokenCtx, tokenCancel := context.WithTimeout(h.ctx, httpRequestTimeout)
+			tokenReq, err := http.NewRequestWithContext(tokenCtx, http.MethodPost, tokenEndpoint, strings.NewReader(tokenReqBody.Encode()))
+			if err != nil {
+				tokenCancel()
+				return nil, fmt.Errorf("could not build token request: %w", err)
+			}
+			tokenReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			tokenResp, err := h.httpClient.Do(tokenReq)
+			tokenCancel()
+			if err != nil {
+				return nil, fmt.Errorf("token polling request failed: %w", err)
+			}
+
+			// Handle the token response based on the status code.
+			if tokenResp.StatusCode == http.StatusOK {
+				var rawToken struct {
+					AccessToken  string `json:"access_token"`
+					TokenType    string `json:"token_type"`
+					RefreshToken string `json:"refresh_token"`
+					IDToken      string `json:"id_token"`
+					ExpiresIn    int    `json:"expires_in"`
+				}
+				err := json.NewDecoder(tokenResp.Body).Decode(&rawToken)
+				tokenResp.Body.Close()
+				if err != nil {
+					return nil, fmt.Errorf("failed to decode token response: %w", err)
+				}
+
+				// Validate the ID token and extract claims.
+				verifiedIDToken, err := h.validateIDToken(h.ctx, h.provider, h.clientID, rawToken.IDToken)
+				if err != nil {
+					return nil, fmt.Errorf("failed to validate ID token: %w", err)
+				}
+
+				// Extract claims from the verified ID token.
+				var claims map[string]any
+				if err := verifiedIDToken.Claims(&claims); err != nil {
+					return nil, fmt.Errorf("failed to extract claims from ID token: %w", err)
+				}
+
+				token := &oidctypes.Token{
+					AccessToken: &oidctypes.AccessToken{
+						Token: rawToken.AccessToken,
+					},
+					IDToken: &oidctypes.IDToken{
+						Token:  rawToken.IDToken,
+						Claims: claims,
+						Expiry: metav1.NewTime(verifiedIDToken.Expiry),
+					},
+				}
+				if rawToken.RefreshToken != "" {
+					token.RefreshToken = &oidctypes.RefreshToken{
+						Token: rawToken.RefreshToken,
+					}
+				}
+
+				return token, nil
+			}
+
+			// Handle error responses from the token endpoint.
+			var errResp oauth2ErrorResponse
+			_ = json.NewDecoder(tokenResp.Body).Decode(&errResp)
+			tokenResp.Body.Close()
+
+			switch errResp.Error {
+			case "authorization_pending":
+				continue
+
+			case "slow_down":
+				interval += 5 * time.Second
+				pollTicker.Reset(interval)
+				continue
+
+			case "expired_token":
+				return nil, fmt.Errorf("device code has expired, please try logging in again")
+
+			case "access_denied":
+				return nil, fmt.Errorf("login access was denied by the user")
+
+			default:
+				if errResp.ErrorDescription != "" {
+					return nil, fmt.Errorf("login failed: %s (%s)", errResp.Error, errResp.ErrorDescription)
+				}
+				return nil, fmt.Errorf("login failed with error: %s", errResp.Error)
+			}
+		}
+	}
+}

--- a/pkg/oidcclient/devicecode_test.go
+++ b/pkg/oidcclient/devicecode_test.go
@@ -1,0 +1,224 @@
+package oidcclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+// テスト用の疑似 ID Token (JWT) を作成するヘルパー関数
+func generateTestIDToken(issuer, audience, subject string) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256","typ":"JWT"}`))
+	payload := base64.RawURLEncoding.EncodeToString([]byte(fmt.Sprintf(
+		`{"iss":%q,"sub":%q,"aud":%q,"exp":%d,"iat":%d}`,
+		issuer, subject, audience, time.Now().Add(time.Hour).Unix(), time.Now().Unix(),
+	)))
+	signature := base64.RawURLEncoding.EncodeToString([]byte("fake-signature"))
+	return fmt.Sprintf("%s.%s.%s", header, payload, signature)
+}
+
+func TestDeviceCodeBasedAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		setupServer    func(t *testing.T) *httptest.Server
+		ctxTimeout     time.Duration
+		wantErr        string
+		wantIDTokenSub string
+	}{
+		{
+			name: "success: device code flow completes after polling pending once",
+			setupServer: func(t *testing.T) *httptest.Server {
+				var pollCount int32
+				var server *httptest.Server
+
+				server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/.well-known/openid-configuration":
+						w.Header().Set("Content-Type", "application/json")
+						_ = json.NewEncoder(w).Encode(map[string]any{
+							"issuer":                        server.URL,
+							"authorization_endpoint":        server.URL + "/auth",
+							"token_endpoint":                server.URL + "/token",
+							"device_authorization_endpoint": server.URL + "/device/code",
+							"jwks_uri":                      server.URL + "/jwks",
+						})
+
+					case "/device/code":
+						require.Equal(t, http.MethodPost, r.Method)
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "test-client-id", r.Form.Get("client_id"))
+
+						w.Header().Set("Content-Type", "application/json")
+						_ = json.NewEncoder(w).Encode(deviceAuthorizationResponse{
+							DeviceCode:      "test-device-code",
+							UserCode:        "ABCD-1234",
+							VerificationURI: "https://example.com/device",
+							ExpiresIn:       300,
+							Interval:        1,
+						})
+
+					case "/token":
+						require.Equal(t, http.MethodPost, r.Method)
+						require.NoError(t, r.ParseForm())
+						require.Equal(t, "urn:ietf:params:oauth:grant-type:device_code", r.Form.Get("grant_type"))
+						require.Equal(t, "test-device-code", r.Form.Get("device_code"))
+
+						count := atomic.AddInt32(&pollCount, 1)
+						w.Header().Set("Content-Type", "application/json")
+
+						if count == 1 {
+							// 1回目は authorization_pending
+							w.WriteHeader(http.StatusBadRequest)
+							_ = json.NewEncoder(w).Encode(oauth2ErrorResponse{
+								Error: "authorization_pending",
+							})
+							return
+						}
+
+						// 2回目で成功トークンを返す
+						idToken := generateTestIDToken(server.URL, "test-client-id", "test-user-id")
+						_ = json.NewEncoder(w).Encode(map[string]any{
+							"access_token":  "test-access-token",
+							"token_type":    "Bearer",
+							"id_token":      idToken,
+							"refresh_token": "test-refresh-token",
+							"expires_in":    3600,
+						})
+
+					default:
+						http.NotFound(w, r)
+					}
+				}))
+				return server
+			},
+			ctxTimeout:     5 * time.Second,
+			wantIDTokenSub: "test-user-id",
+		},
+		{
+			name: "error: missing device_authorization_endpoint in discovery",
+			setupServer: func(t *testing.T) *httptest.Server {
+				var server *httptest.Server
+				server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/.well-known/openid-configuration" {
+						w.Header().Set("Content-Type", "application/json")
+						_ = json.NewEncoder(w).Encode(map[string]any{
+							"issuer":                 server.URL,
+							"authorization_endpoint": server.URL + "/auth",
+							"token_endpoint":         server.URL + "/token",
+						})
+						return
+					}
+					http.NotFound(w, r)
+				}))
+				return server
+			},
+			ctxTimeout: 2 * time.Second,
+			wantErr:    "issuer does not support device authorization grant",
+		},
+		{
+			name: "error: access denied by user",
+			setupServer: func(t *testing.T) *httptest.Server {
+				var server *httptest.Server
+				server = httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/.well-known/openid-configuration":
+						w.Header().Set("Content-Type", "application/json")
+						_ = json.NewEncoder(w).Encode(map[string]any{
+							"issuer":                        server.URL,
+							"device_authorization_endpoint": server.URL + "/device/code",
+							"token_endpoint":                server.URL + "/token",
+						})
+					case "/device/code":
+						w.Header().Set("Content-Type", "application/json")
+						_ = json.NewEncoder(w).Encode(deviceAuthorizationResponse{
+							DeviceCode:      "test-device-code",
+							UserCode:        "ABCD-1234",
+							VerificationURI: "https://example.com/device",
+							Interval:        1,
+						})
+					case "/token":
+						w.Header().Set("Content-Type", "application/json")
+						w.WriteHeader(http.StatusBadRequest)
+						_ = json.NewEncoder(w).Encode(oauth2ErrorResponse{
+							Error: "access_denied",
+						})
+					}
+				}))
+				return server
+			},
+			ctxTimeout: 3 * time.Second,
+			wantErr:    "login access was denied by the user",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := tt.setupServer(t)
+			defer server.Close()
+
+			client := server.Client()
+			ctx := oidc.ClientContext(context.Background(), client)
+			ctx, cancel := context.WithTimeout(ctx, tt.ctxTimeout)
+			defer cancel()
+
+			provider, err := oidc.NewProvider(ctx, server.URL)
+			require.NoError(t, err)
+
+			out := &bytes.Buffer{}
+			h := &handlerState{
+				ctx:        ctx,
+				clientID:   "test-client-id",
+				provider:   provider,
+				httpClient: client,
+				oauth2Config: &oauth2.Config{
+					ClientID: "test-client-id",
+					Endpoint: oauth2.Endpoint{
+						TokenURL: server.URL + "/token",
+					},
+				},
+				scopes: []string{"openid", "profile"},
+				out:    out,
+				validateIDToken: func(ctx context.Context, _ *oidc.Provider, audience string, token string) (*oidc.IDToken, error) {
+					// 署名検証をスキップして JWT を正常パース
+					verifier := provider.Verifier(&oidc.Config{
+						InsecureSkipSignatureCheck: true,
+						SkipClientIDCheck:          true,
+						SkipExpiryCheck:            true,
+						SkipIssuerCheck:            true,
+					})
+					return verifier.Verify(ctx, token)
+				},
+			}
+
+			token, err := h.deviceCodeBasedAuth(nil)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, token)
+				require.Equal(t, "test-access-token", token.AccessToken.Token)
+				require.Equal(t, tt.wantIDTokenSub, token.IDToken.Claims["sub"])
+				require.Contains(t, out.String(), "https://example.com/device")
+				require.Contains(t, out.String(), "ABCD-1234")
+			}
+		})
+	}
+}

--- a/pkg/oidcclient/login.go
+++ b/pkg/oidcclient/login.go
@@ -319,20 +319,23 @@ func WithCLISendingCredentials() Option {
 // could potentially get logged somewhere by the issuer.
 // When the argument is equal to idpdiscoveryv1alpha1.IDPFlowBrowserAuthcode, it will attempt to open a web browser
 // and perform the OIDC authcode flow.
+// When the argument is equal to idpdiscoveryv1alpha1.IDPFlowDeviceCode, it will attempt to use the device code flow.
 // When not used, the default when the issuer is a Pinniped Supervisor will be determined automatically,
 // and the default for non-Supervisor issuers will be the browser authcode flow.
 func WithLoginFlow(loginFlow idpdiscoveryv1alpha1.IDPFlow, flowSource string) Option {
 	return func(h *handlerState) error {
 		switch loginFlow {
 		case idpdiscoveryv1alpha1.IDPFlowCLIPassword,
-			idpdiscoveryv1alpha1.IDPFlowBrowserAuthcode:
+			idpdiscoveryv1alpha1.IDPFlowBrowserAuthcode,
+			idpdiscoveryv1alpha1.IDPFlowDeviceCode:
 		default:
 			return fmt.Errorf(
-				"WithLoginFlow error: loginFlow '%s' from '%s' must be '%s' or '%s'",
+				"WithLoginFlow error: loginFlow '%s' from '%s' must be '%s', '%s' or '%s'",
 				loginFlow,
 				flowSource,
 				idpdiscoveryv1alpha1.IDPFlowCLIPassword,
 				idpdiscoveryv1alpha1.IDPFlowBrowserAuthcode,
+				idpdiscoveryv1alpha1.IDPFlowDeviceCode,
 			)
 		}
 		h.loginFlow = loginFlow
@@ -479,17 +482,19 @@ func Login(issuer string, clientID string, opts ...Option) (*oidctypes.Token, er
 
 	// Initialize login parameters.
 	var err error
-	h.state, err = h.generateState()
-	if err != nil {
-		return nil, err
-	}
-	h.nonce, err = h.generateNonce()
-	if err != nil {
-		return nil, err
-	}
-	h.pkce, err = h.generatePKCE()
-	if err != nil {
-		return nil, err
+	if h.loginFlow != idpdiscoveryv1alpha1.IDPFlowDeviceCode {
+		h.state, err = h.generateState()
+		if err != nil {
+			return nil, err
+		}
+		h.nonce, err = h.generateNonce()
+		if err != nil {
+			return nil, err
+		}
+		h.pkce, err = h.generatePKCE()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Do the basic login to get an access and ID token issued to our main client ID.
@@ -606,6 +611,8 @@ func (h *handlerState) baseLogin() (*oidctypes.Token, error) {
 		authFunc = h.cliBasedAuth
 	case idpdiscoveryv1alpha1.IDPFlowBrowserAuthcode:
 		// NOOP
+	case idpdiscoveryv1alpha1.IDPFlowDeviceCode:
+		authFunc = h.deviceCodeBasedAuth
 	}
 
 	// Perform the authorize request and authcode exchange to get back OIDC tokens.


### PR DESCRIPTION
## Summary

This PR introduces/enhances support for the OAuth 2.0 Device Authorization Grant (RFC 8628) in the Pinniped CLI.

### Background / Details
- Enables seamless authentication in browserless / SSH environments where direct browser redirect (PKCE authorization code flow) is not feasible.
- Prompts the user with a verification URL and user code, polling the IdP token endpoint until authentication is completed on another device.
- Ensures compatibility with standard OIDC/OAuth2 IdPs supporting the device authorization flow.

## Fixes

resolve #3225

## Release note

```release-note
Added support for OAuth 2.0 Device Authorization Grant (Device Code Flow) in Pinniped CLI, allowing authentication in headless and SSH environments via a secondary device.
```