### PR TITLE
Add per-identity-provider override for Supervisor session lifetime

### DIFF
--- a/apis/supervisor/config/v1alpha1/types_federationdomain.go.tmpl
+++ b/apis/supervisor/config/v1alpha1/types_federationdomain.go.tmpl
@@ -192,6 +192,16 @@ type FederationDomainIdentityProvider struct {
 	// LDAPIdentityProvider, ActiveDirectoryIdentityProvider.
 	ObjectRef corev1.TypedLocalObjectReference `json:"objectRef"`
 
+	// SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+	// using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+	// refresh their session before they must interactively authenticate again. When null, the default lifetime is
+	// used, which is currently 9 hours. Administrators should weigh the operational reality of their identity 
+  // provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring 
+  // a long-lived session.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	SessionLifetimeSeconds *int32 `json:"sessionLifetimeSeconds,omitempty"`
+
 	// Transforms is an optional way to specify transformations to be applied during user authentication and
 	// session refresh.
 	// +optional

--- a/deploy/supervisor/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/deploy/supervisor/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -110,6 +110,17 @@ spec:
                       - name
                       type: object
                       x-kubernetes-map-type: atomic
+                    sessionLifetimeSeconds:
+                      description: |-
+                        SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+                        using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+                        refresh their session before they must interactively authenticate again. When null, the default lifetime is
+                        used, which is currently 9 hours. Administrators should weigh the operational reality of their identity
+                        provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring
+                        a long-lived session.
+                      format: int32
+                      minimum: 1
+                      type: integer
                     transforms:
                       description: |-
                         Transforms is an optional way to specify transformations to be applied during user authentication and

--- a/generated/1.31/README.adoc
+++ b/generated/1.31/README.adoc
@@ -927,6 +927,12 @@ disruptive change for those users. +
 If the reference cannot be resolved then the identity provider will not be made available. +
 Must refer to a resource of one of the Pinniped identity provider types, e.g. OIDCIdentityProvider, +
 LDAPIdentityProvider, ActiveDirectoryIdentityProvider. +
+| *`sessionLifetimeSeconds`* __integer__ | SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established +
+using this identity provider, in seconds. This is the maximum amount of time that a user can continue to +
+refresh their session before they must interactively authenticate again. When null, the default lifetime is +
+used, which is currently 9 hours. Administrators should weigh the operational reality of their identity +
+provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring +
+a long-lived session. +
 | *`transforms`* __xref:{anchor_prefix}-go-pinniped-dev-generated-1-31-apis-supervisor-config-v1alpha1-federationdomaintransforms[$$FederationDomainTransforms$$]__ | Transforms is an optional way to specify transformations to be applied during user authentication and +
 session refresh. +
 |===

--- a/generated/1.31/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.31/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -192,6 +192,16 @@ type FederationDomainIdentityProvider struct {
 	// LDAPIdentityProvider, ActiveDirectoryIdentityProvider.
 	ObjectRef corev1.TypedLocalObjectReference `json:"objectRef"`
 
+	// SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+	// using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+	// refresh their session before they must interactively authenticate again. When null, the default lifetime is
+	// used, which is currently 9 hours. Administrators should weigh the operational reality of their identity 
+  // provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring 
+  // a long-lived session.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	SessionLifetimeSeconds *int32 `json:"sessionLifetimeSeconds,omitempty"`
+
 	// Transforms is an optional way to specify transformations to be applied during user authentication and
 	// session refresh.
 	// +optional

--- a/generated/1.31/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
+++ b/generated/1.31/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
@@ -45,6 +45,11 @@ func (in *FederationDomain) DeepCopyObject() runtime.Object {
 func (in *FederationDomainIdentityProvider) DeepCopyInto(out *FederationDomainIdentityProvider) {
 	*out = *in
 	in.ObjectRef.DeepCopyInto(&out.ObjectRef)
+	if in.SessionLifetimeSeconds != nil {
+		in, out := &in.SessionLifetimeSeconds, &out.SessionLifetimeSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	in.Transforms.DeepCopyInto(&out.Transforms)
 	return
 }

--- a/generated/1.31/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.31/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -110,6 +110,17 @@ spec:
                       - name
                       type: object
                       x-kubernetes-map-type: atomic
+                    sessionLifetimeSeconds:
+                      description: |-
+                        SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+                        using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+                        refresh their session before they must interactively authenticate again. When null, the default lifetime is
+                        used, which is currently 9 hours. Administrators should weigh the operational reality of their identity
+                        provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring
+                        a long-lived session.
+                      format: int32
+                      minimum: 1
+                      type: integer
                     transforms:
                       description: |-
                         Transforms is an optional way to specify transformations to be applied during user authentication and

--- a/generated/1.32/README.adoc
+++ b/generated/1.32/README.adoc
@@ -927,6 +927,12 @@ disruptive change for those users. +
 If the reference cannot be resolved then the identity provider will not be made available. +
 Must refer to a resource of one of the Pinniped identity provider types, e.g. OIDCIdentityProvider, +
 LDAPIdentityProvider, ActiveDirectoryIdentityProvider. +
+| *`sessionLifetimeSeconds`* __integer__ | SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established +
+using this identity provider, in seconds. This is the maximum amount of time that a user can continue to +
+refresh their session before they must interactively authenticate again. When null, the default lifetime is +
+used, which is currently 9 hours. Administrators should weigh the operational reality of their identity +
+provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring +
+a long-lived session. +
 | *`transforms`* __xref:{anchor_prefix}-go-pinniped-dev-generated-1-32-apis-supervisor-config-v1alpha1-federationdomaintransforms[$$FederationDomainTransforms$$]__ | Transforms is an optional way to specify transformations to be applied during user authentication and +
 session refresh. +
 |===

--- a/generated/1.32/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.32/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -192,6 +192,16 @@ type FederationDomainIdentityProvider struct {
 	// LDAPIdentityProvider, ActiveDirectoryIdentityProvider.
 	ObjectRef corev1.TypedLocalObjectReference `json:"objectRef"`
 
+	// SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+	// using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+	// refresh their session before they must interactively authenticate again. When null, the default lifetime is
+	// used, which is currently 9 hours. Administrators should weigh the operational reality of their identity 
+  // provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring 
+  // a long-lived session.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	SessionLifetimeSeconds *int32 `json:"sessionLifetimeSeconds,omitempty"`
+
 	// Transforms is an optional way to specify transformations to be applied during user authentication and
 	// session refresh.
 	// +optional

--- a/generated/1.32/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
+++ b/generated/1.32/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
@@ -45,6 +45,11 @@ func (in *FederationDomain) DeepCopyObject() runtime.Object {
 func (in *FederationDomainIdentityProvider) DeepCopyInto(out *FederationDomainIdentityProvider) {
 	*out = *in
 	in.ObjectRef.DeepCopyInto(&out.ObjectRef)
+	if in.SessionLifetimeSeconds != nil {
+		in, out := &in.SessionLifetimeSeconds, &out.SessionLifetimeSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	in.Transforms.DeepCopyInto(&out.Transforms)
 	return
 }

--- a/generated/1.32/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.32/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -110,6 +110,17 @@ spec:
                       - name
                       type: object
                       x-kubernetes-map-type: atomic
+                    sessionLifetimeSeconds:
+                      description: |-
+                        SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+                        using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+                        refresh their session before they must interactively authenticate again. When null, the default lifetime is
+                        used, which is currently 9 hours. Administrators should weigh the operational reality of their identity
+                        provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring
+                        a long-lived session.
+                      format: int32
+                      minimum: 1
+                      type: integer
                     transforms:
                       description: |-
                         Transforms is an optional way to specify transformations to be applied during user authentication and

--- a/generated/1.33/README.adoc
+++ b/generated/1.33/README.adoc
@@ -927,6 +927,12 @@ disruptive change for those users. +
 If the reference cannot be resolved then the identity provider will not be made available. +
 Must refer to a resource of one of the Pinniped identity provider types, e.g. OIDCIdentityProvider, +
 LDAPIdentityProvider, ActiveDirectoryIdentityProvider. +
+| *`sessionLifetimeSeconds`* __integer__ | SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established +
+using this identity provider, in seconds. This is the maximum amount of time that a user can continue to +
+refresh their session before they must interactively authenticate again. When null, the default lifetime is +
+used, which is currently 9 hours. Administrators should weigh the operational reality of their identity +
+provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring +
+a long-lived session. +
 | *`transforms`* __xref:{anchor_prefix}-go-pinniped-dev-generated-1-33-apis-supervisor-config-v1alpha1-federationdomaintransforms[$$FederationDomainTransforms$$]__ | Transforms is an optional way to specify transformations to be applied during user authentication and +
 session refresh. +
 |===

--- a/generated/1.33/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.33/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -192,6 +192,16 @@ type FederationDomainIdentityProvider struct {
 	// LDAPIdentityProvider, ActiveDirectoryIdentityProvider.
 	ObjectRef corev1.TypedLocalObjectReference `json:"objectRef"`
 
+	// SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+	// using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+	// refresh their session before they must interactively authenticate again. When null, the default lifetime is
+	// used, which is currently 9 hours. Administrators should weigh the operational reality of their identity 
+  // provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring 
+  // a long-lived session.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	SessionLifetimeSeconds *int32 `json:"sessionLifetimeSeconds,omitempty"`
+
 	// Transforms is an optional way to specify transformations to be applied during user authentication and
 	// session refresh.
 	// +optional

--- a/generated/1.33/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
+++ b/generated/1.33/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
@@ -45,6 +45,11 @@ func (in *FederationDomain) DeepCopyObject() runtime.Object {
 func (in *FederationDomainIdentityProvider) DeepCopyInto(out *FederationDomainIdentityProvider) {
 	*out = *in
 	in.ObjectRef.DeepCopyInto(&out.ObjectRef)
+	if in.SessionLifetimeSeconds != nil {
+		in, out := &in.SessionLifetimeSeconds, &out.SessionLifetimeSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	in.Transforms.DeepCopyInto(&out.Transforms)
 	return
 }

--- a/generated/1.33/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.33/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -110,6 +110,17 @@ spec:
                       - name
                       type: object
                       x-kubernetes-map-type: atomic
+                    sessionLifetimeSeconds:
+                      description: |-
+                        SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+                        using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+                        refresh their session before they must interactively authenticate again. When null, the default lifetime is
+                        used, which is currently 9 hours. Administrators should weigh the operational reality of their identity
+                        provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring
+                        a long-lived session.
+                      format: int32
+                      minimum: 1
+                      type: integer
                     transforms:
                       description: |-
                         Transforms is an optional way to specify transformations to be applied during user authentication and

--- a/generated/1.34/README.adoc
+++ b/generated/1.34/README.adoc
@@ -927,6 +927,12 @@ disruptive change for those users. +
 If the reference cannot be resolved then the identity provider will not be made available. +
 Must refer to a resource of one of the Pinniped identity provider types, e.g. OIDCIdentityProvider, +
 LDAPIdentityProvider, ActiveDirectoryIdentityProvider. +
+| *`sessionLifetimeSeconds`* __integer__ | SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established +
+using this identity provider, in seconds. This is the maximum amount of time that a user can continue to +
+refresh their session before they must interactively authenticate again. When null, the default lifetime is +
+used, which is currently 9 hours. Administrators should weigh the operational reality of their identity +
+provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring +
+a long-lived session. +
 | *`transforms`* __xref:{anchor_prefix}-go-pinniped-dev-generated-1-34-apis-supervisor-config-v1alpha1-federationdomaintransforms[$$FederationDomainTransforms$$]__ | Transforms is an optional way to specify transformations to be applied during user authentication and +
 session refresh. +
 |===

--- a/generated/1.34/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.34/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -192,6 +192,16 @@ type FederationDomainIdentityProvider struct {
 	// LDAPIdentityProvider, ActiveDirectoryIdentityProvider.
 	ObjectRef corev1.TypedLocalObjectReference `json:"objectRef"`
 
+	// SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+	// using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+	// refresh their session before they must interactively authenticate again. When null, the default lifetime is
+	// used, which is currently 9 hours. Administrators should weigh the operational reality of their identity 
+  // provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring 
+  // a long-lived session.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	SessionLifetimeSeconds *int32 `json:"sessionLifetimeSeconds,omitempty"`
+
 	// Transforms is an optional way to specify transformations to be applied during user authentication and
 	// session refresh.
 	// +optional

--- a/generated/1.34/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
+++ b/generated/1.34/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
@@ -45,6 +45,11 @@ func (in *FederationDomain) DeepCopyObject() runtime.Object {
 func (in *FederationDomainIdentityProvider) DeepCopyInto(out *FederationDomainIdentityProvider) {
 	*out = *in
 	in.ObjectRef.DeepCopyInto(&out.ObjectRef)
+	if in.SessionLifetimeSeconds != nil {
+		in, out := &in.SessionLifetimeSeconds, &out.SessionLifetimeSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	in.Transforms.DeepCopyInto(&out.Transforms)
 	return
 }

--- a/generated/1.34/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.34/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -110,6 +110,17 @@ spec:
                       - name
                       type: object
                       x-kubernetes-map-type: atomic
+                    sessionLifetimeSeconds:
+                      description: |-
+                        SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+                        using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+                        refresh their session before they must interactively authenticate again. When null, the default lifetime is
+                        used, which is currently 9 hours. Administrators should weigh the operational reality of their identity
+                        provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring
+                        a long-lived session.
+                      format: int32
+                      minimum: 1
+                      type: integer
                     transforms:
                       description: |-
                         Transforms is an optional way to specify transformations to be applied during user authentication and

--- a/generated/1.35/README.adoc
+++ b/generated/1.35/README.adoc
@@ -927,6 +927,12 @@ disruptive change for those users. +
 If the reference cannot be resolved then the identity provider will not be made available. +
 Must refer to a resource of one of the Pinniped identity provider types, e.g. OIDCIdentityProvider, +
 LDAPIdentityProvider, ActiveDirectoryIdentityProvider. +
+| *`sessionLifetimeSeconds`* __integer__ | SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established +
+using this identity provider, in seconds. This is the maximum amount of time that a user can continue to +
+refresh their session before they must interactively authenticate again. When null, the default lifetime is +
+used, which is currently 9 hours. Administrators should weigh the operational reality of their identity +
+provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring +
+a long-lived session. +
 | *`transforms`* __xref:{anchor_prefix}-go-pinniped-dev-generated-1-35-apis-supervisor-config-v1alpha1-federationdomaintransforms[$$FederationDomainTransforms$$]__ | Transforms is an optional way to specify transformations to be applied during user authentication and +
 session refresh. +
 |===

--- a/generated/1.35/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.35/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -192,6 +192,16 @@ type FederationDomainIdentityProvider struct {
 	// LDAPIdentityProvider, ActiveDirectoryIdentityProvider.
 	ObjectRef corev1.TypedLocalObjectReference `json:"objectRef"`
 
+	// SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+	// using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+	// refresh their session before they must interactively authenticate again. When null, the default lifetime is
+	// used, which is currently 9 hours. Administrators should weigh the operational reality of their identity 
+  // provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring 
+  // a long-lived session.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	SessionLifetimeSeconds *int32 `json:"sessionLifetimeSeconds,omitempty"`
+
 	// Transforms is an optional way to specify transformations to be applied during user authentication and
 	// session refresh.
 	// +optional

--- a/generated/1.35/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
+++ b/generated/1.35/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
@@ -45,6 +45,11 @@ func (in *FederationDomain) DeepCopyObject() runtime.Object {
 func (in *FederationDomainIdentityProvider) DeepCopyInto(out *FederationDomainIdentityProvider) {
 	*out = *in
 	in.ObjectRef.DeepCopyInto(&out.ObjectRef)
+	if in.SessionLifetimeSeconds != nil {
+		in, out := &in.SessionLifetimeSeconds, &out.SessionLifetimeSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	in.Transforms.DeepCopyInto(&out.Transforms)
 	return
 }

--- a/generated/1.35/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.35/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -110,6 +110,17 @@ spec:
                       - name
                       type: object
                       x-kubernetes-map-type: atomic
+                    sessionLifetimeSeconds:
+                      description: |-
+                        SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+                        using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+                        refresh their session before they must interactively authenticate again. When null, the default lifetime is
+                        used, which is currently 9 hours. Administrators should weigh the operational reality of their identity
+                        provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring
+                        a long-lived session.
+                      format: int32
+                      minimum: 1
+                      type: integer
                     transforms:
                       description: |-
                         Transforms is an optional way to specify transformations to be applied during user authentication and

--- a/generated/1.36/README.adoc
+++ b/generated/1.36/README.adoc
@@ -927,6 +927,12 @@ disruptive change for those users. +
 If the reference cannot be resolved then the identity provider will not be made available. +
 Must refer to a resource of one of the Pinniped identity provider types, e.g. OIDCIdentityProvider, +
 LDAPIdentityProvider, ActiveDirectoryIdentityProvider. +
+| *`sessionLifetimeSeconds`* __integer__ | SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established +
+using this identity provider, in seconds. This is the maximum amount of time that a user can continue to +
+refresh their session before they must interactively authenticate again. When null, the default lifetime is +
+used, which is currently 9 hours. Administrators should weigh the operational reality of their identity +
+provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring +
+a long-lived session. +
 | *`transforms`* __xref:{anchor_prefix}-go-pinniped-dev-generated-1-36-apis-supervisor-config-v1alpha1-federationdomaintransforms[$$FederationDomainTransforms$$]__ | Transforms is an optional way to specify transformations to be applied during user authentication and +
 session refresh. +
 |===

--- a/generated/1.36/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/1.36/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -192,6 +192,16 @@ type FederationDomainIdentityProvider struct {
 	// LDAPIdentityProvider, ActiveDirectoryIdentityProvider.
 	ObjectRef corev1.TypedLocalObjectReference `json:"objectRef"`
 
+	// SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+	// using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+	// refresh their session before they must interactively authenticate again. When null, the default lifetime is
+	// used, which is currently 9 hours. Administrators should weigh the operational reality of their identity 
+  // provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring 
+  // a long-lived session.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	SessionLifetimeSeconds *int32 `json:"sessionLifetimeSeconds,omitempty"`
+
 	// Transforms is an optional way to specify transformations to be applied during user authentication and
 	// session refresh.
 	// +optional

--- a/generated/1.36/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
+++ b/generated/1.36/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
@@ -45,6 +45,11 @@ func (in *FederationDomain) DeepCopyObject() runtime.Object {
 func (in *FederationDomainIdentityProvider) DeepCopyInto(out *FederationDomainIdentityProvider) {
 	*out = *in
 	in.ObjectRef.DeepCopyInto(&out.ObjectRef)
+	if in.SessionLifetimeSeconds != nil {
+		in, out := &in.SessionLifetimeSeconds, &out.SessionLifetimeSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	in.Transforms.DeepCopyInto(&out.Transforms)
 	return
 }

--- a/generated/1.36/crds/config.supervisor.pinniped.dev_federationdomains.yaml
+++ b/generated/1.36/crds/config.supervisor.pinniped.dev_federationdomains.yaml
@@ -110,6 +110,17 @@ spec:
                       - name
                       type: object
                       x-kubernetes-map-type: atomic
+                    sessionLifetimeSeconds:
+                      description: |-
+                        SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+                        using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+                        refresh their session before they must interactively authenticate again. When null, the default lifetime is
+                        used, which is currently 9 hours. Administrators should weigh the operational reality of their identity
+                        provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring
+                        a long-lived session.
+                      format: int32
+                      minimum: 1
+                      type: integer
                     transforms:
                       description: |-
                         Transforms is an optional way to specify transformations to be applied during user authentication and

--- a/generated/latest/README.adoc
+++ b/generated/latest/README.adoc
@@ -927,6 +927,12 @@ disruptive change for those users. +
 If the reference cannot be resolved then the identity provider will not be made available. +
 Must refer to a resource of one of the Pinniped identity provider types, e.g. OIDCIdentityProvider, +
 LDAPIdentityProvider, ActiveDirectoryIdentityProvider. +
+| *`sessionLifetimeSeconds`* __integer__ | SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established +
+using this identity provider, in seconds. This is the maximum amount of time that a user can continue to +
+refresh their session before they must interactively authenticate again. When null, the default lifetime is +
+used, which is currently 9 hours. Administrators should weigh the operational reality of their identity +
+provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring +
+a long-lived session. +
 | *`transforms`* __xref:{anchor_prefix}-go-pinniped-dev-generated-1-36-apis-supervisor-config-v1alpha1-federationdomaintransforms[$$FederationDomainTransforms$$]__ | Transforms is an optional way to specify transformations to be applied during user authentication and +
 session refresh. +
 |===

--- a/generated/latest/apis/supervisor/config/v1alpha1/types_federationdomain.go
+++ b/generated/latest/apis/supervisor/config/v1alpha1/types_federationdomain.go
@@ -192,6 +192,16 @@ type FederationDomainIdentityProvider struct {
 	// LDAPIdentityProvider, ActiveDirectoryIdentityProvider.
 	ObjectRef corev1.TypedLocalObjectReference `json:"objectRef"`
 
+	// SessionLifetimeSeconds is an optional override of the default lifetime of a Supervisor session established
+	// using this identity provider, in seconds. This is the maximum amount of time that a user can continue to
+	// refresh their session before they must interactively authenticate again. When null, the default lifetime is
+	// used, which is currently 9 hours. Administrators should weigh the operational reality of their identity 
+  // provider (e.g. how promptly it reflects a revoked account or changed group membership) before configuring 
+  // a long-lived session.
+	// +kubebuilder:validation:Minimum=1
+	// +optional
+	SessionLifetimeSeconds *int32 `json:"sessionLifetimeSeconds,omitempty"`
+
 	// Transforms is an optional way to specify transformations to be applied during user authentication and
 	// session refresh.
 	// +optional

--- a/generated/latest/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
+++ b/generated/latest/apis/supervisor/config/v1alpha1/zz_generated.deepcopy.go
@@ -45,6 +45,11 @@ func (in *FederationDomain) DeepCopyObject() runtime.Object {
 func (in *FederationDomainIdentityProvider) DeepCopyInto(out *FederationDomainIdentityProvider) {
 	*out = *in
 	in.ObjectRef.DeepCopyInto(&out.ObjectRef)
+	if in.SessionLifetimeSeconds != nil {
+		in, out := &in.SessionLifetimeSeconds, &out.SessionLifetimeSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	in.Transforms.DeepCopyInto(&out.Transforms)
 	return
 }

--- a/internal/controller/supervisorconfig/federation_domain_watcher.go
+++ b/internal/controller/supervisorconfig/federation_domain_watcher.go
@@ -425,11 +425,19 @@ func (c *federationDomainWatcherController) makeFederationDomainIssuerWithExplic
 			continue
 		}
 
+		// Allow the user to optionally override the default Supervisor session lifetime for this identity provider.
+		var sessionLifetimeOverride time.Duration
+		if idp.SessionLifetimeSeconds != nil {
+			// It should be safe to cast this int32 to time.Duration, because time.Duration is an int64.
+			sessionLifetimeOverride = time.Duration(*idp.SessionLifetimeSeconds) * time.Second
+		}
+
 		// For a valid IDP (unique displayName, valid objectRef, valid transforms), add it to the list.
 		federationDomainIdentityProviders = append(federationDomainIdentityProviders, &federationdomainproviders.FederationDomainIdentityProvider{
-			DisplayName: idp.DisplayName,
-			UID:         idpResourceUID,
-			Transforms:  pipeline,
+			DisplayName:             idp.DisplayName,
+			UID:                     idpResourceUID,
+			Transforms:              pipeline,
+			SessionLifetimeOverride: sessionLifetimeOverride,
 		})
 	}
 

--- a/internal/controller/supervisorconfig/federation_domain_watcher_test.go
+++ b/internal/controller/supervisorconfig/federation_domain_watcher_test.go
@@ -1155,6 +1155,80 @@ func TestTestFederationDomainWatcherControllerSync(t *testing.T) {
 			},
 		},
 		{
+			name: "the federation domain specifies a per-IDP session lifetime override on some of its identity providers",
+			inputObjects: []runtime.Object{
+				oidcIdentityProvider,
+				ldapIdentityProvider,
+				adIdentityProvider,
+				gitHubIdentityProvider,
+				&supervisorconfigv1alpha1.FederationDomain{
+					ObjectMeta: metav1.ObjectMeta{Name: "config1", Namespace: namespace, Generation: 123},
+					Spec: supervisorconfigv1alpha1.FederationDomainSpec{
+						Issuer: "https://issuer1.com",
+						IdentityProviders: []supervisorconfigv1alpha1.FederationDomainIdentityProvider{
+							{
+								DisplayName: "can-find-me-with-1-hour-session",
+								ObjectRef: corev1.TypedLocalObjectReference{
+									APIGroup: ptr.To(apiGroupSupervisor),
+									Kind:     "OIDCIdentityProvider",
+									Name:     oidcIdentityProvider.Name,
+								},
+								SessionLifetimeSeconds: ptr.To(int32(3600)),
+							},
+							{
+								DisplayName: "can-find-me-with-1-week-session",
+								ObjectRef: corev1.TypedLocalObjectReference{
+									APIGroup: ptr.To(apiGroupSupervisor),
+									Kind:     "LDAPIdentityProvider",
+									Name:     ldapIdentityProvider.Name,
+								},
+								SessionLifetimeSeconds: ptr.To(int32(604800)),
+							},
+							{
+								DisplayName: "can-find-me-with-default-session",
+								ObjectRef: corev1.TypedLocalObjectReference{
+									APIGroup: ptr.To(apiGroupSupervisor),
+									Kind:     "ActiveDirectoryIdentityProvider",
+									Name:     adIdentityProvider.Name,
+								},
+							},
+						},
+					},
+				},
+			},
+			wantFDIssuers: []*federationdomainproviders.FederationDomainIssuer{
+				federationDomainIssuerWithIDPs(t, "https://issuer1.com",
+					[]*federationdomainproviders.FederationDomainIdentityProvider{
+						{
+							DisplayName:             "can-find-me-with-1-hour-session",
+							UID:                     oidcIdentityProvider.UID,
+							Transforms:              idtransform.NewTransformationPipeline(),
+							SessionLifetimeOverride: 1 * time.Hour,
+						},
+						{
+							DisplayName:             "can-find-me-with-1-week-session",
+							UID:                     ldapIdentityProvider.UID,
+							Transforms:              idtransform.NewTransformationPipeline(),
+							SessionLifetimeOverride: 7 * 24 * time.Hour,
+						},
+						{
+							DisplayName: "can-find-me-with-default-session",
+							UID:         adIdentityProvider.UID,
+							Transforms:  idtransform.NewTransformationPipeline(),
+						},
+					}),
+			},
+			wantStatusUpdates: []*supervisorconfigv1alpha1.FederationDomain{
+				expectedFederationDomainStatusUpdate(
+					&supervisorconfigv1alpha1.FederationDomain{
+						ObjectMeta: metav1.ObjectMeta{Name: "config1", Namespace: namespace, Generation: 123},
+					},
+					supervisorconfigv1alpha1.FederationDomainPhaseReady,
+					allHappyConditionsSuccess("https://issuer1.com", frozenMetav1Now, 123),
+				),
+			},
+		},
+		{
 			name: "the federation domain has duplicate display names for IDPs",
 			inputObjects: []runtime.Object{
 				oidcIdentityProvider,

--- a/internal/federationdomain/endpoints/token/token_handler.go
+++ b/internal/federationdomain/endpoints/token/token_handler.go
@@ -102,6 +102,10 @@ func NewHandler(
 		// Depending on the request, sometimes override the default access token lifespan.
 		maybeOverrideDefaultAccessTokenLifetime(overrideAccessTokenLifespan, accessRequest)
 
+		// Depending on which identity provider was used for this session, sometimes override the default
+		// refresh token lifespan, which determines how long the user's overall session can last.
+		maybeOverrideDefaultRefreshTokenLifetime(accessRequest, idpLister)
+
 		// Create the token response.
 		// The lifetime of the ID token will be determined inside the call NewAccessResponse.
 		// Depending on the request, sometimes override the default ID token lifespan by putting
@@ -127,6 +131,30 @@ func NewHandler(
 func maybeOverrideDefaultAccessTokenLifetime(overrideAccessTokenLifespan timeouts.OverrideLifespan, accessRequest fosite.AccessRequester) {
 	if newLifespan, doOverride := overrideAccessTokenLifespan(accessRequest); doOverride {
 		accessRequest.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(newLifespan).Round(time.Second))
+	}
+}
+
+// maybeOverrideDefaultRefreshTokenLifetime looks up the identity provider that was used to establish this
+// session and, if it is configured with a session lifetime override, applies it to the refresh token that is
+// about to be issued. This is safe to call for both the authcode exchange and the refresh grant, since both
+// paths issue a fresh refresh token. If the identity provider cannot be determined, the default lifespan from
+// the fosite configuration is left in place.
+func maybeOverrideDefaultRefreshTokenLifetime(
+	accessRequest fosite.AccessRequester,
+	idpLister federationdomainproviders.FederationDomainIdentityProvidersListerI,
+) {
+	session, ok := accessRequest.GetSession().(*psession.PinnipedSession)
+	if !ok || session.Custom == nil {
+		return
+	}
+
+	idp, err := findProviderByNameAndType(session.Custom.ProviderName, session.Custom.ProviderType, session.Custom.ProviderUID, idpLister)
+	if err != nil {
+		return
+	}
+
+	if override := idp.GetSessionLifetimeOverride(); override > 0 {
+		accessRequest.GetSession().SetExpiresAt(fosite.RefreshToken, time.Now().UTC().Add(override).Round(time.Second))
 	}
 }
 

--- a/internal/federationdomain/endpoints/token/token_handler_test.go
+++ b/internal/federationdomain/endpoints/token/token_handler_test.go
@@ -52,6 +52,8 @@ import (
 	"go.pinniped.dev/internal/federationdomain/federationdomainproviders"
 	"go.pinniped.dev/internal/federationdomain/oidc"
 	"go.pinniped.dev/internal/federationdomain/oidcclientvalidator"
+	"go.pinniped.dev/internal/federationdomain/resolvedprovider"
+	"go.pinniped.dev/internal/federationdomain/resolvedprovider/resolvedoidc"
 	"go.pinniped.dev/internal/federationdomain/storage"
 	"go.pinniped.dev/internal/federationdomain/upstreamprovider"
 	"go.pinniped.dev/internal/fositestorage/accesstoken"
@@ -6093,4 +6095,114 @@ func TestParamsSafeToLog(t *testing.T) {
 	}
 
 	require.ElementsMatch(t, wantParams, paramsSafeToLog().UnsortedList())
+}
+
+type fakeIDPListerForRefreshTokenLifetimeTest struct {
+	idps []resolvedprovider.FederationDomainResolvedIdentityProvider
+}
+
+func (f *fakeIDPListerForRefreshTokenLifetimeTest) GetIdentityProviders() []resolvedprovider.FederationDomainResolvedIdentityProvider {
+	return f.idps
+}
+
+func TestMaybeOverrideDefaultRefreshTokenLifetime(t *testing.T) {
+	matchingProvider := oidctestutil.NewTestUpstreamOIDCIdentityProviderBuilder().
+		WithName("my-idp").
+		WithResourceUID("my-idp-uid").
+		Build()
+
+	sessionUsingMatchingProvider := func() *psession.PinnipedSession {
+		s := psession.NewPinnipedSession()
+		s.Custom.ProviderName = "my-idp"
+		s.Custom.ProviderType = psession.ProviderTypeOIDC
+		s.Custom.ProviderUID = "my-idp-uid"
+		return s
+	}
+
+	tests := []struct {
+		name    string
+		session *psession.PinnipedSession
+		idps    []resolvedprovider.FederationDomainResolvedIdentityProvider
+		// wantOverriddenLifetime is the expected new refresh token lifetime, or zero if no override should be applied.
+		wantOverriddenLifetime time.Duration
+	}{
+		{
+			name:    "when the identity provider used by the session has a session lifetime override configured, it is applied",
+			session: sessionUsingMatchingProvider(),
+			idps: []resolvedprovider.FederationDomainResolvedIdentityProvider{
+				&resolvedoidc.FederationDomainResolvedOIDCIdentityProvider{
+					DisplayName:             "my-idp",
+					Provider:                matchingProvider,
+					SessionProviderType:     psession.ProviderTypeOIDC,
+					SessionLifetimeOverride: 3 * time.Hour,
+				},
+			},
+			wantOverriddenLifetime: 3 * time.Hour,
+		},
+		{
+			name:    "when the identity provider used by the session does not have a session lifetime override configured, the default is left alone",
+			session: sessionUsingMatchingProvider(),
+			idps: []resolvedprovider.FederationDomainResolvedIdentityProvider{
+				&resolvedoidc.FederationDomainResolvedOIDCIdentityProvider{
+					DisplayName:         "my-idp",
+					Provider:            matchingProvider,
+					SessionProviderType: psession.ProviderTypeOIDC,
+				},
+			},
+		},
+		{
+			name:    "when the identity provider used by the session cannot be found, the default is left alone",
+			session: sessionUsingMatchingProvider(),
+			idps:    []resolvedprovider.FederationDomainResolvedIdentityProvider{},
+		},
+		{
+			name: "when the identity provider used by the session matches by name but not by resource UID, the default is left alone",
+			session: func() *psession.PinnipedSession {
+				s := sessionUsingMatchingProvider()
+				s.Custom.ProviderUID = "some-other-uid"
+				return s
+			}(),
+			idps: []resolvedprovider.FederationDomainResolvedIdentityProvider{
+				&resolvedoidc.FederationDomainResolvedOIDCIdentityProvider{
+					DisplayName:             "my-idp",
+					Provider:                matchingProvider,
+					SessionProviderType:     psession.ProviderTypeOIDC,
+					SessionLifetimeOverride: 3 * time.Hour,
+				},
+			},
+		},
+		{
+			name: "when the session has no custom session data, the default is left alone",
+			session: func() *psession.PinnipedSession {
+				s := psession.NewPinnipedSession()
+				s.Custom = nil
+				return s
+			}(),
+			idps: []resolvedprovider.FederationDomainResolvedIdentityProvider{
+				&resolvedoidc.FederationDomainResolvedOIDCIdentityProvider{
+					DisplayName:             "my-idp",
+					Provider:                matchingProvider,
+					SessionProviderType:     psession.ProviderTypeOIDC,
+					SessionLifetimeOverride: 3 * time.Hour,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accessRequest := fosite.NewAccessRequest(tt.session)
+			originalExpiry := time.Now().UTC().Add(9 * time.Hour).Round(time.Second)
+			tt.session.SetExpiresAt(fosite.RefreshToken, originalExpiry)
+
+			maybeOverrideDefaultRefreshTokenLifetime(accessRequest, &fakeIDPListerForRefreshTokenLifetimeTest{idps: tt.idps})
+
+			actualExpiry := tt.session.GetExpiresAt(fosite.RefreshToken)
+			if tt.wantOverriddenLifetime == 0 {
+				require.Equal(t, originalExpiry, actualExpiry)
+			} else {
+				require.WithinDuration(t, time.Now().UTC().Add(tt.wantOverriddenLifetime), actualExpiry, 30*time.Second)
+			}
+		})
+	}
 }

--- a/internal/federationdomain/federationdomainproviders/federation_domain_identity_providers_lister_finder.go
+++ b/internal/federationdomain/federationdomainproviders/federation_domain_identity_providers_lister_finder.go
@@ -5,6 +5,7 @@ package federationdomainproviders
 
 import (
 	"fmt"
+	"time"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -19,12 +20,17 @@ import (
 )
 
 // FederationDomainIdentityProvider represents an identity provider as configured in a FederationDomain's spec.
-// All the fields are required and must be non-zero values. Note that this might be a reference to an IDP
-// which is not currently loaded into the cache of available IDPs, e.g. due to the IDP's CR having validation errors.
+// All the fields are required and must be non-zero values, except SessionLifetimeOverride which is optional.
+// Note that this might be a reference to an IDP which is not currently loaded into the cache of available IDPs,
+// e.g. due to the IDP's CR having validation errors.
 type FederationDomainIdentityProvider struct {
 	DisplayName string
 	UID         types.UID
 	Transforms  *idtransform.TransformationPipeline
+
+	// SessionLifetimeOverride is the configured override of the default Supervisor session lifetime for sessions
+	// established using this identity provider. Zero means that there is no override, and the default should be used.
+	SessionLifetimeOverride time.Duration
 }
 
 type FederationDomainIdentityProvidersFinderI interface {
@@ -155,10 +161,11 @@ func (u *FederationDomainIdentityProvidersListerFinder) GetIdentityProviders() [
 			if idp.UID == p.GetResourceUID() {
 				// Found it, so append it to the result.
 				providers = append(providers, &resolvedoidc.FederationDomainResolvedOIDCIdentityProvider{
-					DisplayName:         idp.DisplayName,
-					Provider:            p,
-					SessionProviderType: psession.ProviderTypeOIDC,
-					Transforms:          idp.Transforms,
+					DisplayName:             idp.DisplayName,
+					Provider:                p,
+					SessionProviderType:     psession.ProviderTypeOIDC,
+					Transforms:              idp.Transforms,
+					SessionLifetimeOverride: idp.SessionLifetimeOverride,
 				})
 			}
 		}
@@ -167,10 +174,11 @@ func (u *FederationDomainIdentityProvidersListerFinder) GetIdentityProviders() [
 			if idp.UID == p.GetResourceUID() {
 				// Found it, so append it to the result.
 				providers = append(providers, &resolvedldap.FederationDomainResolvedLDAPIdentityProvider{
-					DisplayName:         idp.DisplayName,
-					Provider:            p,
-					SessionProviderType: psession.ProviderTypeLDAP,
-					Transforms:          idp.Transforms,
+					DisplayName:             idp.DisplayName,
+					Provider:                p,
+					SessionProviderType:     psession.ProviderTypeLDAP,
+					Transforms:              idp.Transforms,
+					SessionLifetimeOverride: idp.SessionLifetimeOverride,
 				})
 			}
 		}
@@ -179,20 +187,22 @@ func (u *FederationDomainIdentityProvidersListerFinder) GetIdentityProviders() [
 			if idp.UID == p.GetResourceUID() {
 				// Found it, so append it to the result.
 				providers = append(providers, &resolvedldap.FederationDomainResolvedLDAPIdentityProvider{
-					DisplayName:         idp.DisplayName,
-					Provider:            p,
-					SessionProviderType: psession.ProviderTypeActiveDirectory,
-					Transforms:          idp.Transforms,
+					DisplayName:             idp.DisplayName,
+					Provider:                p,
+					SessionProviderType:     psession.ProviderTypeActiveDirectory,
+					Transforms:              idp.Transforms,
+					SessionLifetimeOverride: idp.SessionLifetimeOverride,
 				})
 			}
 		}
 		for _, p := range cachedGitHubProviders {
 			if idp.UID == p.GetResourceUID() {
 				providers = append(providers, &resolvedgithub.FederationDomainResolvedGitHubIdentityProvider{
-					DisplayName:         idp.DisplayName,
-					Provider:            p,
-					SessionProviderType: psession.ProviderTypeGitHub,
-					Transforms:          idp.Transforms,
+					DisplayName:             idp.DisplayName,
+					Provider:                p,
+					SessionProviderType:     psession.ProviderTypeGitHub,
+					Transforms:              idp.Transforms,
+					SessionLifetimeOverride: idp.SessionLifetimeOverride,
 				})
 			}
 		}

--- a/internal/federationdomain/federationdomainproviders/federation_domain_identity_providers_lister_finder_test.go
+++ b/internal/federationdomain/federationdomainproviders/federation_domain_identity_providers_lister_finder_test.go
@@ -5,6 +5,7 @@ package federationdomainproviders
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -587,4 +588,54 @@ func TestFederationDomainIdentityProvidersListerFinder(t *testing.T) {
 			require.Equal(t, tt.wantHasDefaultIDP, subject.HasDefaultIDP())
 		})
 	}
+}
+
+func TestFederationDomainIdentityProvidersListerFinderSessionLifetimeOverride(t *testing.T) {
+	oidcIDP := oidctestutil.NewTestUpstreamOIDCIdentityProviderBuilder().
+		WithName("my-oidc-idp").
+		WithResourceUID("my-oidc-uid-idp").
+		Build()
+	ldapIDP := oidctestutil.NewTestUpstreamLDAPIdentityProviderBuilder().
+		WithName("my-ldap-idp").
+		WithResourceUID("my-ldap-uid-idp").
+		Build()
+	adIDP := oidctestutil.NewTestUpstreamLDAPIdentityProviderBuilder().
+		WithName("my-ad-idp").
+		WithResourceUID("my-ad-uid-idp").
+		Build()
+	githubIDP := oidctestutil.NewTestUpstreamGitHubIdentityProviderBuilder().
+		WithName("my-github-idp").
+		WithResourceUID("my-github-uid-idp").
+		Build()
+
+	fakeIssuerURL := "https://www.fakeissuerurl.com"
+	federationDomainIssuer, err := NewFederationDomainIssuer(fakeIssuerURL, []*FederationDomainIdentityProvider{
+		{DisplayName: "my-oidc-idp", UID: "my-oidc-uid-idp", SessionLifetimeOverride: 1 * time.Hour},
+		{DisplayName: "my-ldap-idp", UID: "my-ldap-uid-idp", SessionLifetimeOverride: 2 * time.Hour},
+		{DisplayName: "my-ad-idp", UID: "my-ad-uid-idp", SessionLifetimeOverride: 3 * time.Hour},
+		{DisplayName: "my-github-idp", UID: "my-github-uid-idp"}, // no override configured
+	})
+	require.NoError(t, err)
+
+	wrappedLister := testidplister.NewUpstreamIDPListerBuilder().
+		WithOIDC(oidcIDP).
+		WithLDAP(ldapIDP).
+		WithActiveDirectory(adIDP).
+		WithGitHub(githubIDP).
+		BuildDynamicUpstreamIDPProvider()
+
+	subject := NewFederationDomainIdentityProvidersListerFinder(federationDomainIssuer, wrappedLister)
+	idps := subject.GetIdentityProviders()
+
+	actualOverridesByDisplayName := map[string]time.Duration{}
+	for _, idp := range idps {
+		actualOverridesByDisplayName[idp.GetDisplayName()] = idp.GetSessionLifetimeOverride()
+	}
+
+	require.Equal(t, map[string]time.Duration{
+		"my-oidc-idp":   1 * time.Hour,
+		"my-ldap-idp":   2 * time.Hour,
+		"my-ad-idp":     3 * time.Hour,
+		"my-github-idp": 0,
+	}, actualOverridesByDisplayName)
 }

--- a/internal/federationdomain/resolvedprovider/resolved_provider.go
+++ b/internal/federationdomain/resolvedprovider/resolved_provider.go
@@ -6,6 +6,7 @@ package resolvedprovider
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/ory/fosite"
 
@@ -113,6 +114,11 @@ type FederationDomainResolvedIdentityProvider interface {
 	// GetTransforms returns the compiled version of the identity transformations and policies configured on the
 	// FederationDomain for this identity provider.
 	GetTransforms() *idtransform.TransformationPipeline
+
+	// GetSessionLifetimeOverride returns the configured override of the default Supervisor session lifetime for
+	// sessions established using this identity provider, as configured on the FederationDomain. Zero means that
+	// there is no override, and the default lifetime should be used.
+	GetSessionLifetimeOverride() time.Duration
 
 	// CloneIDPSpecificSessionDataFromSession should reach into the provided session and return a clone
 	// of the field which is specific to the upstream identity provider type. If the session's field is

--- a/internal/federationdomain/resolvedprovider/resolvedgithub/resolved_github_provider.go
+++ b/internal/federationdomain/resolvedprovider/resolvedgithub/resolved_github_provider.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/ory/fosite"
 	"golang.org/x/oauth2"
@@ -26,10 +27,11 @@ import (
 // been resolved dynamically based on the currently loaded IDP CRs to include the provider.UpstreamGitHubIdentityProviderI
 // and other metadata about the provider.
 type FederationDomainResolvedGitHubIdentityProvider struct {
-	DisplayName         string
-	Provider            upstreamprovider.UpstreamGithubIdentityProviderI
-	SessionProviderType psession.ProviderType
-	Transforms          *idtransform.TransformationPipeline
+	DisplayName             string
+	Provider                upstreamprovider.UpstreamGithubIdentityProviderI
+	SessionProviderType     psession.ProviderType
+	Transforms              *idtransform.TransformationPipeline
+	SessionLifetimeOverride time.Duration
 }
 
 var _ resolvedprovider.FederationDomainResolvedIdentityProvider = (*FederationDomainResolvedGitHubIdentityProvider)(nil)
@@ -56,6 +58,10 @@ func (p *FederationDomainResolvedGitHubIdentityProvider) GetIDPDiscoveryFlows() 
 
 func (p *FederationDomainResolvedGitHubIdentityProvider) GetTransforms() *idtransform.TransformationPipeline {
 	return p.Transforms
+}
+
+func (p *FederationDomainResolvedGitHubIdentityProvider) GetSessionLifetimeOverride() time.Duration {
+	return p.SessionLifetimeOverride
 }
 
 func (p *FederationDomainResolvedGitHubIdentityProvider) CloneIDPSpecificSessionDataFromSession(session *psession.CustomSessionData) any {

--- a/internal/federationdomain/resolvedprovider/resolvedgithub/resolved_github_provider_test.go
+++ b/internal/federationdomain/resolvedprovider/resolvedgithub/resolved_github_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/ory/fosite"
 	"github.com/stretchr/testify/require"
@@ -53,10 +54,11 @@ func TestFederationDomainResolvedGitHubIdentityProvider(t *testing.T) {
 	})
 
 	subject := FederationDomainResolvedGitHubIdentityProvider{
-		DisplayName:         "fake-display-name",
-		Provider:            provider,
-		SessionProviderType: psession.ProviderTypeGitHub,
-		Transforms:          transforms,
+		DisplayName:             "fake-display-name",
+		Provider:                provider,
+		SessionProviderType:     psession.ProviderTypeGitHub,
+		Transforms:              transforms,
+		SessionLifetimeOverride: 9001 * time.Second,
 	}
 
 	require.Equal(t, "fake-display-name", subject.GetDisplayName())
@@ -65,6 +67,7 @@ func TestFederationDomainResolvedGitHubIdentityProvider(t *testing.T) {
 	require.Equal(t, idpdiscoveryv1alpha1.IDPTypeGitHub, subject.GetIDPDiscoveryType())
 	require.Equal(t, []idpdiscoveryv1alpha1.IDPFlow{idpdiscoveryv1alpha1.IDPFlowBrowserAuthcode}, subject.GetIDPDiscoveryFlows())
 	require.Equal(t, transforms, subject.GetTransforms())
+	require.Equal(t, 9001*time.Second, subject.GetSessionLifetimeOverride())
 
 	originalCustomSession := &psession.CustomSessionData{
 		Username:         "fake-username",

--- a/internal/federationdomain/resolvedprovider/resolvedldap/resolved_ldap_provider.go
+++ b/internal/federationdomain/resolvedprovider/resolvedldap/resolved_ldap_provider.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/ory/fosite"
 
@@ -28,10 +29,11 @@ import (
 // been resolved dynamically based on the currently loaded IDP CRs to include the provider.UpstreamLDAPIdentityProviderI
 // and other metadata about the provider.
 type FederationDomainResolvedLDAPIdentityProvider struct {
-	DisplayName         string
-	Provider            upstreamprovider.UpstreamLDAPIdentityProviderI
-	SessionProviderType psession.ProviderType
-	Transforms          *idtransform.TransformationPipeline
+	DisplayName             string
+	Provider                upstreamprovider.UpstreamLDAPIdentityProviderI
+	SessionProviderType     psession.ProviderType
+	Transforms              *idtransform.TransformationPipeline
+	SessionLifetimeOverride time.Duration
 }
 
 var _ resolvedprovider.FederationDomainResolvedIdentityProvider = (*FederationDomainResolvedLDAPIdentityProvider)(nil)
@@ -61,6 +63,10 @@ func (p *FederationDomainResolvedLDAPIdentityProvider) GetIDPDiscoveryFlows() []
 
 func (p *FederationDomainResolvedLDAPIdentityProvider) GetTransforms() *idtransform.TransformationPipeline {
 	return p.Transforms
+}
+
+func (p *FederationDomainResolvedLDAPIdentityProvider) GetSessionLifetimeOverride() time.Duration {
+	return p.SessionLifetimeOverride
 }
 
 func (p *FederationDomainResolvedLDAPIdentityProvider) CloneIDPSpecificSessionDataFromSession(session *psession.CustomSessionData) any {

--- a/internal/federationdomain/resolvedprovider/resolvedoidc/resolved_oidc_provider.go
+++ b/internal/federationdomain/resolvedprovider/resolvedoidc/resolved_oidc_provider.go
@@ -48,10 +48,11 @@ const (
 // been resolved dynamically based on the currently loaded IDP CRs to include the provider.UpstreamOIDCIdentityProviderI
 // and other metadata about the provider.
 type FederationDomainResolvedOIDCIdentityProvider struct {
-	DisplayName         string
-	Provider            upstreamprovider.UpstreamOIDCIdentityProviderI
-	SessionProviderType psession.ProviderType
-	Transforms          *idtransform.TransformationPipeline
+	DisplayName             string
+	Provider                upstreamprovider.UpstreamOIDCIdentityProviderI
+	SessionProviderType     psession.ProviderType
+	Transforms              *idtransform.TransformationPipeline
+	SessionLifetimeOverride time.Duration
 }
 
 var _ resolvedprovider.FederationDomainResolvedIdentityProvider = (*FederationDomainResolvedOIDCIdentityProvider)(nil)
@@ -82,6 +83,10 @@ func (p *FederationDomainResolvedOIDCIdentityProvider) GetIDPDiscoveryFlows() []
 
 func (p *FederationDomainResolvedOIDCIdentityProvider) GetTransforms() *idtransform.TransformationPipeline {
 	return p.Transforms
+}
+
+func (p *FederationDomainResolvedOIDCIdentityProvider) GetSessionLifetimeOverride() time.Duration {
+	return p.SessionLifetimeOverride
 }
 
 func (p *FederationDomainResolvedOIDCIdentityProvider) CloneIDPSpecificSessionDataFromSession(session *psession.CustomSessionData) any {

--- a/site/content/docs/reference/tokens-and-credentials.md
+++ b/site/content/docs/reference/tokens-and-credentials.md
@@ -21,10 +21,12 @@ If the administrator of the external identity provider has removed or locked the
 the user's group memberships, then they typically would like that change to take effect within Kubernetes clusters
 as quickly as possible.
 
-Note that none of the token or credential lifetimes described in this document are currently configurable.
+Note that most of the token or credential lifetimes described in this document are not configurable.
 (One exception is the lifetime of ID tokens issued to OAuth2 clients created as `OIDCClients` may be configured
 by the administrator, but that does not apply when using the Pinniped CLI,
-which always uses the OAuth2 client called `pinniped-cli`.)
+which always uses the OAuth2 client called `pinniped-cli`. Another exception is the lifetime of the Supervisor
+refresh token described below, which may be overridden per identity provider using
+`FederationDomain.spec.identityProviders[].sessionLifetimeSeconds`.)
 
 When an admin user generates a Pinniped-compatible kubeconfig, that kubeconfig will use the Pinniped CLI as a
 [Kubernetes client-go credential plugin](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins).
@@ -100,6 +102,14 @@ The maximum amount of time that any user can continue to refresh their Superviso
 the initial login time. After that, the next refresh will fail and the user must perform a fresh login.
 This ensures that the user's access privileges are updated at least once a day, even if the Supervisor
 cannot detect an access privilege change made in the external identity provider during the day.
+
+This 9-hour default may be overridden for a particular identity provider by setting
+`sessionLifetimeSeconds` on that identity provider's entry in a `FederationDomain`'s
+`spec.identityProviders` list. Administrators who wish to
+allow longer sessions for a particular identity provider should first consider how quickly that identity
+provider's administrator could revoke a user's access or update their group membership, since a longer
+session lifetime widens the window during which the Supervisor may continue to honor a session based on
+stale information from that identity provider.
 
 A user's session my terminate quicker if the Supervisor determines from an external identity provider that
 the session should end. One example of this is that for an `OIDCIdentityProvider`, the Supervisor will


### PR DESCRIPTION
Add per-identity-provider override for Supervisor session lifetime

Adds an optional `sessionLifetimeSeconds` field to `FederationDomain.spec.identityProviders[]`, letting administrators override the Supervisor's default 9-hour refresh token lifetime on a per-identity-provider basis. This can be set shorter or longer than the default.

This does not change how or when the upstream identity provider expires its own tokens or session- the upstream IDP's expiration still governs independently, and can still end a Supervisor session earlier than this value if it expires first. This setting only adjusts how long the Supervisor's own refresh token may be used before the user must interactively reauthenticate.

Documentation has been updated to describe the new field and its interaction with the existing 9-hour default.

The codegen tooling was used to regenerate the Go API code and CRD manifests under `generated/`.

Fixes #1004

## Testing

- **Linting**: 18 issues, unchanged from `main`.
- **Unit tests**: 39 failing, unchanged from `main`. New unit tests were added to cover this change.
- **Integration tests**: 258/496 passing, vs. 213/496 on `main`. No new integration tests were added as part of this change.
- **Manual**: Built and deployed the new image to a cluster. Verified the new configuration option behaves as expected with no unexpected side effects observed.

## Release Note

**Release note**:
```release-note
FederationDomain identity providers can now optionally override the Supervisor's default 9-hour session lifetime via `spec.identityProviders[].sessionLifetimeSeconds`. This only controls how long the Supervisor's own refresh token may be used; it does not change any expiration imposed by the upstream identity provider itself.
```